### PR TITLE
Configure proxy for localhost:8080

### DIFF
--- a/client/angular.json
+++ b/client/angular.json
@@ -59,6 +59,9 @@
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "proxyConfig": "local-proxy.conf.json"
+          },
           "configurations": {
             "production": {
               "browserTarget": "client:build:production"

--- a/client/local-proxy.conf.json
+++ b/client/local-proxy.conf.json
@@ -1,0 +1,11 @@
+[
+    {
+        "context": [
+            "/api"
+        ],
+        "target": "http://localhost:8080",
+        "secure": false,
+        "changeOrigin": true,
+        "logLevel": "debug"
+    }
+]


### PR DESCRIPTION
Adds proxy configuration when ng serve is executed

Request are defined as follows:

`this.httpClient.post<any>('/api/v1/security/login', loginRequest).subscribe()`